### PR TITLE
Fix #36 replace archive page footer

### DIFF
--- a/templates/archive.php
+++ b/templates/archive.php
@@ -108,7 +108,7 @@ get_header();
 		?>
 	</section>
 	<?php Render\archive_pagination(); ?>
-	<?php get_template_part( 'parts/footers' ); ?>
+	<?php get_template_part( 'build/templates/footer' ); ?>
 
 </main><!--/#page-->
 


### PR DESCRIPTION
## Description

Changes to the HRS theme meant the Courses archive page footer disappeared. Replace it to fix #36.

## How has this been tested?

Works as expected in local environment.

## Checklist:

- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run test` -->
- [x] My code follows the accessibility standards. <!-- Guidelines: -->
- [x] My code has proper inline documentation. <!-- Guidelines: -->
- [x] I've included developer documentation if appropriate.
